### PR TITLE
fix: explicitly checkpoint WAL on shutdown to ensure consolidation

### DIFF
--- a/src/metadata/sqlite.rs
+++ b/src/metadata/sqlite.rs
@@ -836,6 +836,14 @@ impl MetadataStore {
 
     /// Gracefully close the metadata store, flushing WAL to the main database.
     pub async fn close(&self) {
+        // Explicitly checkpoint and truncate the WAL before closing.
+        // pool.close() alone only passively checkpoints which may leave WAL files behind.
+        if let Err(e) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .execute(&self.pool)
+            .await
+        {
+            tracing::warn!("WAL checkpoint failed during shutdown: {e}");
+        }
         self.pool.close().await;
     }
 


### PR DESCRIPTION
## Summary

- Add an explicit `PRAGMA wal_checkpoint(TRUNCATE)` call before closing the SQLite connection pool during shutdown
- `pool.close()` alone only triggers a passive checkpoint, which can leave WAL/SHM files behind after the process exits
- Downgrade `taskmill` from 0.7.1 to 0.6.0 to match the API used in the codebase

## Why

SQLite WAL mode relies on checkpointing to consolidate write-ahead log data back into the main database file. The default passive checkpoint performed by `sqlx::Pool::close()` is best-effort and may leave `-wal` and `-shm` files on disk after shutdown. Over time (or after unclean exits), this can lead to stale WAL files or unexpected state on restart. A `TRUNCATE` checkpoint forces full consolidation and removes the WAL file.

## Test plan

- [x] Verify the server shuts down cleanly without leftover `-wal`/`-shm` files
- [x] Confirm existing integration tests pass (`cargo test`)
- [x] Verify `taskmill` 0.6.0 compiles and works correctly with the current task scheduling code
